### PR TITLE
filament-samples-vk

### DIFF
--- a/recipes-graphics/filament/filament-samples-vk_git.bb
+++ b/recipes-graphics/filament/filament-samples-vk_git.bb
@@ -1,0 +1,63 @@
+SUMMARY = "Lightweight 3D Render Engine Samples"
+DESCRIPTION = "Filament is a real-time physically based rendering engine for Android, iOS, Windows, Linux, macOS, and WebGL2"
+AUTHOR = "Filament Authors"
+HOMEPAGE = "https://github.com/jwinarske/filament-samples"
+BUGTRACKER = "https://github.com/jwinarske/filament-samples/issues"
+SECTION = "graphics"
+CVE_PRODUCT = ""
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+DEPENDS += "\
+    assimp \
+    compiler-rt \
+    filament-vk \
+    filament-vk-native \
+    libcxx \
+    libpng \
+    libxkbcommon \
+    llvm \
+    virtual/egl \
+    vulkan-headers \
+    vulkan-loader \
+    wayland \
+    wayland-native \
+    "
+
+PV .= "+${SRCPV}"
+
+SRC_URI = "git://github.com/jwinarske/filament-samples;protocol=https;branch=main"
+
+SRCREV = "${AUTOREV}"
+
+RUNTIME = "llvm"
+TOOLCHAIN = "clang"
+PREFERRED_PROVIDER:libgcc = "compiler-rt"
+
+PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"
+
+PACKAGECONFIG[wayland] = "-DFILAMENT_SUPPORTS_WAYLAND=ON,-DFILAMENT_SUPPORTS_WAYLAND=OFF,wayland"
+PACKAGECONFIG[x11] = "-DFILAMENT_SUPPORTS_X11=ON,-DFILAMENT_SUPPORTS_X11=OFF,libxcb libx11 libxrandr"
+
+inherit cmake pkgconfig
+
+EXTRA_OECMAKE += " \
+    -D CMAKE_SYSROOT=${STAGING_DIR_TARGET}/usr \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D BUILD_SHARED_LIBS=OFF \
+    -D FILAMENT_SUPPORTS_VULKAN=ON \
+    -D FILAMENT_SUPPORTS_OPENGL=OFF \
+    -D FILAMENT_LINUX_IS_MOBILE=ON \
+    -D FILAMENT_SKIP_TESTS=ON \
+    -D FILAMENT_HOST_TOOLS_ROOT=${STAGING_BINDIR_NATIVE} \
+    -D IMPORT_EXECUTABLES=${S}/cmake/ImportExecutables-Release.cmake \
+    -D DIST_ARCH=${BUILD_ARCH} \
+    ${PACKAGECONFIG_CONFARGS} \
+    "
+
+do_install:append() {
+    rm -rf ${D}${libdir}
+    rm -rf ${D}${includedir}
+}
+
+BBCLASSEXTEND = ""

--- a/recipes-graphics/filament/filament-samples-vk_git.bb
+++ b/recipes-graphics/filament/filament-samples-vk_git.bb
@@ -28,6 +28,8 @@ PV .= "+${SRCPV}"
 
 SRC_URI = "git://github.com/jwinarske/filament-samples;protocol=https;branch=main"
 
+S = "${WORKDIR}/git"
+
 SRCREV = "${AUTOREV}"
 
 RUNTIME = "llvm"

--- a/recipes-graphics/filament/filament-vk_git.bb
+++ b/recipes-graphics/filament/filament-vk_git.bb
@@ -11,7 +11,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 DEPENDS += "\
     compiler-rt \
     libcxx \
-    llvm \
     "
 
 DEPENDS:class-target += "\
@@ -23,7 +22,7 @@ DEPENDS:class-target += "\
 PV .= "+${SRCPV}"
 
 SRC_URI = "git://github.com/meta-flutter/filament;protocol=https;branch=yocto \
-           file://ImportExecutables-Release.cmake"
+           file://ImportExecutables-Release.cmake.in"
 
 SRCREV = "${AUTOREV}"
 
@@ -60,6 +59,7 @@ EXTRA_OECMAKE:class-target += " \
     -D CMAKE_BUILD_TYPE=Release \
     -D IMPORT_EXECUTABLES_DIR=. \
     -D FILAMENT_SKIP_SDL2=ON \
+    -D DIST_ARCH=${BUILD_ARCH} \
     -D FILAMENT_HOST_TOOLS_ROOT=${STAGING_BINDIR_NATIVE} \
     ${PACKAGECONFIG_CONFARGS} \
     "
@@ -74,15 +74,14 @@ do_install:append:class-native () {
 }
 
 do_install:append:class-target () {
-    install -d ${D}${libdir}/filament
     mv ${D}${libdir}/*/*.a ${D}${libdir}
-    rm -rf ${D}${libdir}/x86_64
+    rm -rf ${D}${libdir}/${BUILD_ARCH}
     rm ${D}/usr/LICENSE
     rm ${D}/usr/README.md
 }
 
 FILES:${PN}-staticdev += " \
-    ${libdir}/filament \
+    ${libdir} \
     "
 
 BBCLASSEXTEND += "native nativesdk"

--- a/recipes-graphics/filament/filament-vk_git.bb
+++ b/recipes-graphics/filament/filament-vk_git.bb
@@ -23,7 +23,7 @@ DEPENDS:class-target += "\
 PV .= "+${SRCPV}"
 
 SRC_URI = "git://github.com/meta-flutter/filament;protocol=https;branch=yocto \
-           file://ImportExecutables-Release.cmake.in"
+           file://ImportExecutables-Release.cmake"
 
 SRCREV = "${AUTOREV}"
 
@@ -60,17 +60,12 @@ EXTRA_OECMAKE:class-target += " \
     -D CMAKE_BUILD_TYPE=Release \
     -D IMPORT_EXECUTABLES_DIR=. \
     -D FILAMENT_SKIP_SDL2=ON \
+    -D FILAMENT_HOST_TOOLS_ROOT=${STAGING_BINDIR_NATIVE} \
     ${PACKAGECONFIG_CONFARGS} \
     "
 
 do_configure:prepend:class-target () {
-    cp ${WORKDIR}/ImportExecutables-Release.cmake.in ${S}/ImportExecutables-Release.cmake
-    sed -i "s|@MATC_PATH@|${STAGING_BINDIR_NATIVE}/matc|g" ${S}/ImportExecutables-Release.cmake
-    sed -i "s|@CMGEN_PATH@|${STAGING_BINDIR_NATIVE}/cmgen|g" ${S}/ImportExecutables-Release.cmake
-    sed -i "s|@FILAMESH_PATH@|${STAGING_BINDIR_NATIVE}/filamesh|g" ${S}/ImportExecutables-Release.cmake
-    sed -i "s|@MIPGEN_PATH@|${STAGING_BINDIR_NATIVE}/mipgen|g" ${S}/ImportExecutables-Release.cmake
-    sed -i "s|@RESGEN_PATH@|${STAGING_BINDIR_NATIVE}/resgen|g" ${S}/ImportExecutables-Release.cmake
-    sed -i "s|@GLSLMINIFIER_PATH@|${STAGING_BINDIR_NATIVE}/glslminifier|g" ${S}/ImportExecutables-Release.cmake
+    cp ${WORKDIR}/ImportExecutables-Release.cmake ${S}/ImportExecutables-Release.cmake
 }
 
 do_install:append:class-native () {

--- a/recipes-graphics/filament/filament-vk_git.bb
+++ b/recipes-graphics/filament/filament-vk_git.bb
@@ -22,7 +22,7 @@ DEPENDS:class-target += "\
 PV .= "+${SRCPV}"
 
 SRC_URI = "git://github.com/meta-flutter/filament;protocol=https;branch=yocto \
-           file://ImportExecutables-Release.cmake.in"
+           file://ImportExecutables-Release.cmake"
 
 SRCREV = "${AUTOREV}"
 

--- a/recipes-graphics/filament/files/ImportExecutables-Release.cmake
+++ b/recipes-graphics/filament/files/ImportExecutables-Release.cmake
@@ -62,37 +62,37 @@ add_executable(glslminifier IMPORTED)
 # Import target "matc" for configuration "Release"
 set_property(TARGET matc APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
 set_target_properties(matc PROPERTIES
-  IMPORTED_LOCATION_RELEASE "@MATC_PATH@"
+  IMPORTED_LOCATION_RELEASE "${FILAMENT_HOST_TOOLS_ROOT}/matc"
   )
 
 # Import target "cmgen" for configuration "Release"
 set_property(TARGET cmgen APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
 set_target_properties(cmgen PROPERTIES
-  IMPORTED_LOCATION_RELEASE "@CMGEN_PATH@"
+  IMPORTED_LOCATION_RELEASE "${FILAMENT_HOST_TOOLS_ROOT}/cmgen"
   )
 
 # Import target "filamesh" for configuration "Release"
 set_property(TARGET filamesh APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
 set_target_properties(filamesh PROPERTIES
-  IMPORTED_LOCATION_RELEASE "@FILAMESH_PATH@"
+  IMPORTED_LOCATION_RELEASE "${FILAMENT_HOST_TOOLS_ROOT}/filamesh"
   )
 
 # Import target "mipgen" for configuration "Release"
 set_property(TARGET mipgen APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
 set_target_properties(mipgen PROPERTIES
-  IMPORTED_LOCATION_RELEASE "@MIPGEN_PATH@"
+  IMPORTED_LOCATION_RELEASE "${FILAMENT_HOST_TOOLS_ROOT}/mipgen"
   )
 
 # Import target "resgen" for configuration "Release"
 set_property(TARGET resgen APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
 set_target_properties(resgen PROPERTIES
-  IMPORTED_LOCATION_RELEASE "@RESGEN_PATH@"
+  IMPORTED_LOCATION_RELEASE "${FILAMENT_HOST_TOOLS_ROOT}/resgen"
   )
 
 # Import target "glslminifier" for configuration "Release"
 set_property(TARGET glslminifier APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
 set_target_properties(glslminifier PROPERTIES
-  IMPORTED_LOCATION_RELEASE "@GLSLMINIFIER_PATH@"
+  IMPORTED_LOCATION_RELEASE "${FILAMENT_HOST_TOOLS_ROOT}/glslminifier"
   )
 
 # This file does not depend on other imported targets which have


### PR DESCRIPTION
 - Removes sed implementation, ImportExecutables-Release.cmake consumes FILAMENT_HOST_TOOLS_ROOT variable.
    
- Adds filament-samples-vk recipe

    
Signed-off-by: Joel Winarske <joel.winarske@gmail.com>

