### PR TITLE
assimp: use https protocol with github

### DIFF
--- a/recipes-graphics/assimp/assimp_5.0.1.bb
+++ b/recipes-graphics/assimp/assimp_5.0.1.bb
@@ -12,7 +12,7 @@ DEPENDS += "\
     zlib \
 "
 
-SRC_URI = "git://github.com/assimp/assimp.git;branch=assimp_5.0_release \
+SRC_URI = "git://github.com/assimp/assimp.git;protocol=https;branch=assimp_5.0_release \
            file://0001-closes-https-github.com-assimp-assimp-issues-2733-up.patch \
            file://0001-Use-ASSIMP_LIB_INSTALL_DIR-to-search-library.patch \
            "

--- a/recipes-graphics/assimp/assimp_5.2.5.bb
+++ b/recipes-graphics/assimp/assimp_5.2.5.bb
@@ -12,7 +12,7 @@ DEPENDS += "\
     zlib \
 "
 
-SRC_URI = "git://github.com/assimp/assimp.git;branch=master \
+SRC_URI = "git://github.com/assimp/assimp.git;protocol=https;branch=master \
            "
 UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>(\d+(\.\d+)+))"
 


### PR DESCRIPTION
Update the assimp recipes to use https since GitHub deprecated all unauthenticated protocols.