### PR TITLE
Sascha samples

### DIFF
--- a/recipes-graphics/sascha-samples/sascha-samples_git.bb
+++ b/recipes-graphics/sascha-samples/sascha-samples_git.bb
@@ -9,22 +9,25 @@ CVE_PRODUCT = ""
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=dcf473723faabf17baa9b5f2207599d0"
 
-DEPENDS += "\
+DEPENDS += " \
     compiler-rt \
     libcxx \
     openmp \
     vulkan-loader \
-   "
+    glm \
+"
 
 REQUIRED_DISTRO_FEATURES = "vulkan"
 
 SRCREV_FORMAT="sasha-samples"
 
-SRC_URI = "gitsm://github.com/SaschaWillems/Vulkan.git;protocol=https;name=samples;branch=master \
-           git://github.com/SaschaWillems/Vulkan-Assets.git;protocol=https;name=assets;destsuffix=assets;branch=master"
+SRC_URI = " \
+    git://github.com/SaschaWillems/Vulkan.git;protocol=https;name=samples;branch=master \
+    git://github.com/SaschaWillems/Vulkan-Assets.git;protocol=https;name=assets;destsuffix=assets;branch=master \
+"
 
-SRCREV_samples = "79d0c5e436623436b6297a8c81fb3ee8ff78d804"
-SRCREV_assets = "70847d249cbb3e3996d873592363b934ebacb0e0"
+SRCREV_samples = "d9e6ac6ee8a0183918a3f591c41f7776319911fe"
+SRCREV_assets = "cef63c5c44cd0ad53e778ccdb150ff3b650183ab"
 
 S = "${WORKDIR}/git"
 
@@ -35,23 +38,43 @@ TOOLCHAIN = "clang"
 PREFERRED_PROVIDER_libgcc = "compiler-rt"
 PREFERRED_PROVIDER_libgomp = "openmp"
 
-PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"
+PACKAGECONFIG ??= " \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)} \
+"
 
-PACKAGECONFIG[d2d] = "-DUSE_D2D_WSI=ON,-DUSE_D2D_WSI=OFF"
-PACKAGECONFIG[headless] = "-DUSE_HEADLESS=ON,-DUSE_HEADLESS=OFF"
-PACKAGECONFIG[wayland] = "-DUSE_WAYLAND_WSI=ON,-DUSE_WAYLAND_WSI=OFF,wayland wayland-native wayland-protocols"
+# resolve the most common collision automatically by preferring wayland. this
+# really only removes the unnecessary runtime deps. it doesn't change linking
+# options
+
+PACKAGECONFIG:remove ??= " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'x11', '', d)} \
+"
+
+# all of the package config options below are mutually exclusive but they are
+# automatically resolved by cmake logic in the source repo. this list shows the
+# priority of the options from highest to lowest
+
+PACKAGECONFIG[d2d] = "-DUSE_D2D_WSI=ON"
+PACKAGECONFIG[dfb] = "-DUSE_DIRECTFB_WSI=ON"
+PACKAGECONFIG[wayland] = "-DUSE_WAYLAND_WSI=ON,,wayland wayland-native wayland-protocols"
+PACKAGECONFIG[headless] = "-DUSE_HEADLESS=ON"
 PACKAGECONFIG[x11] = ",,libxcb libx11 libxrandr"
 
 EXTRA_OECMAKE += " \
     -DRESOURCE_INSTALL_DIR=${datadir}/vulkan-samples/assets \
     -DCMAKE_INSTALL_BINDIR=${bindir}/vulkan-samples \
-    "
+"
+
+# assets must be copied instead of directly placed in data using the SRC_URI
+# options because yocto will clobber the contents of the destination directory
 
 do_configure:prepend () {
     cp -r ${WORKDIR}/assets/* ${S}/data/
-    rm -rf ${WORKDIR}/assets
 }
 
-FILES:${PN} += "${datadir}"
+FILES:${PN} += " \
+    ${datadir}/vulkan-samples \
+    ${bindir}/vulkan-samples \
+"
 
 BBCLASSEXTEND = ""

--- a/recipes-graphics/vkcube/vkcube_git.bb
+++ b/recipes-graphics/vkcube/vkcube_git.bb
@@ -30,7 +30,7 @@ inherit meson pkgconfig features_check
 PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"
 
 PACKAGECONFIG[wayland] = "-Dwayland=true,-Dwayland=false,wayland wayland-native wayland-protocols"
-PACKAGECONFIG[xcb] = "-Dxcb=true,-Dxcb=false,virtual/libx11 libxcb"
+PACKAGECONFIG[x11] = "-Dxcb=true,-Dxcb=false,virtual/libx11 libxcb"
 
 EXTRA_OEMESON += "--buildtype release"
 

--- a/recipes-graphics/vkmark/vkmark_git.bb
+++ b/recipes-graphics/vkmark/vkmark_git.bb
@@ -8,48 +8,35 @@ CVE_PRODUCT = ""
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING-LGPL2.1;md5=4fbd65380cdd255951079008b364516c"
 
-DEPENDS += "\
+DEPENDS += " \
     assimp \
     glm \
     vulkan-headers \
     vulkan-loader \
-   "
+"
 
 REQUIRED_DISTRO_FEATURES = "vulkan"
 
 S = "${WORKDIR}/git"
 
-SRCREV = "30d2cd37f0566589d90914501fc7c51a4e51f559"
+SRCREV = "ab6e6f34077722d5ae33f6bd40b18ef9c0e99a15"
 
 SRC_URI = "\
     git://github.com/vkmark/vkmark.git;protocol=https;branch=master \
-    file://0001-vulkan_hpp-crosscompile.patch \
 "
 
 inherit meson features_check pkgconfig
 
-PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'wayland xcb', d)}"
+PACKAGECONFIG ??= " \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)} \
+    kms \
+"
 
 PACKAGECONFIG[kms] = "-Dkms=true,-Dkms=false,drm virtual/libgbm"
 PACKAGECONFIG[wayland] = "-Dwayland=true,-Dwayland=false,wayland wayland-native wayland-protocols"
-PACKAGECONFIG[xcb] = "-Dxcb=true,-Dxcb=false,virtual/libx11 libxcb"
+PACKAGECONFIG[x11] = "-Dxcb=true,-Dxcb=false,virtual/libx11 libxcb xcb-util-wm"
 
-EXTRA_OEMESON += "--buildtype release --prefix ${STAGING_DIR_TARGET}/usr"
-
-do_install() {
-    install -d ${D}${datadir}/vkmark/models
-    install -d ${D}${datadir}/vkmark/shaders
-    install -d ${D}${datadir}/vkmark/textures
-
-    cp ${WORKDIR}/build/src/vkmark ${D}${datadir}/vkmark/
-    cp ${WORKDIR}/build/src/wayland.so ${D}${datadir}/vkmark/
-
-    cp -r ${S}/data/models/* ${D}${datadir}/vkmark/models
-    cp -r ${S}/data/shaders/* ${D}${datadir}/vkmark/shaders
-    cp -r ${S}/data/textures/* ${D}${datadir}/vkmark/textures
-
-    rm -rf ${D}${datadir}/man
-}
+EXTRA_OEMESON += "--buildtype release"
 
 FILES:${PN} += "${datadir}"
 


### PR DESCRIPTION
Upgrade the sascha-samples package to latest. Add new PACKAGECONFIG
options and some light dep resolving logic since upstream considers all
wsi extension options to be mutually exclusive.

Adjust vkcube's PACKAGECONFIG variables so the window system selector
works properly and add the necessary compile time dep for the x11 build.